### PR TITLE
Use non-recursive vim mappings

### DIFF
--- a/vim/ftplugin/html/sparkup.vim
+++ b/vim/ftplugin/html/sparkup.vim
@@ -26,10 +26,10 @@ if !exists('g:sparkupNextMapping')
   let g:sparkupNextMapping = '<c-n>'
 endif
 
-exec 'nmap <buffer> ' . g:sparkupExecuteMapping . ' :call <SID>Sparkup()<cr>'
-exec 'imap <buffer> ' . g:sparkupExecuteMapping . ' <c-g>u<Esc>:call <SID>Sparkup()<cr>'
-exec 'nmap <buffer> ' . g:sparkupNextMapping . ' :call <SID>SparkupNext()<cr>'
-exec 'imap <buffer> ' . g:sparkupNextMapping . ' <c-g>u<Esc>:call <SID>SparkupNext()<cr>'
+exec 'nnoremap <buffer> ' . g:sparkupExecuteMapping . ' :call <SID>Sparkup()<cr>'
+exec 'inoremap <buffer> ' . g:sparkupExecuteMapping . ' <c-g>u<Esc>:call <SID>Sparkup()<cr>'
+exec 'nnoremap <buffer> ' . g:sparkupNextMapping . ' :call <SID>SparkupNext()<cr>'
+exec 'inoremap <buffer> ' . g:sparkupNextMapping . ' <c-g>u<Esc>:call <SID>SparkupNext()<cr>'
 
 if exists('*s:Sparkup')
     finish


### PR DESCRIPTION
Just ran into a problem getting sparkup to work with my vimrc settings.
I have my <ESC> key mapped to <NOP>. So <c-e> does nothing when I'm in
insert mode. By convention, when writing vim plugins you should always
use non-recursive mappings so user-defined mappings won't conflict with
your plugins.
