### PR TITLE
Fix for an Insert Mode remapped <Esc>

### DIFF
--- a/vim/ftplugin/html/sparkup.vim
+++ b/vim/ftplugin/html/sparkup.vim
@@ -27,9 +27,9 @@ if !exists('g:sparkupNextMapping')
 endif
 
 exec 'nmap <buffer> ' . g:sparkupExecuteMapping . ' :call <SID>Sparkup()<cr>'
-exec 'imap <buffer> ' . g:sparkupExecuteMapping . ' <c-g>u<Esc>:call <SID>Sparkup()<cr>'
+exec 'inoremap <buffer> ' . g:sparkupExecuteMapping . ' <c-g>u<Esc>:call <SID>Sparkup()<cr>'
 exec 'nmap <buffer> ' . g:sparkupNextMapping . ' :call <SID>SparkupNext()<cr>'
-exec 'imap <buffer> ' . g:sparkupNextMapping . ' <c-g>u<Esc>:call <SID>SparkupNext()<cr>'
+exec 'inoremap <buffer> ' . g:sparkupNextMapping . ' <c-g>u<Esc>:call <SID>SparkupNext()<cr>'
 
 if exists('*s:Sparkup')
     finish


### PR DESCRIPTION
If you've remapped <Esc>(To <nop>, for instance) then the insert mode
mappings fail, ouputting the whole command(:call <SID>Sparkup()) into
the current document.
