### PR TITLE
Update documentation around Vim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ code. It is meant to help you write long HTML blocks in your text editor by lett
 type less characters than needed.
 
 Sparkup is written in Python, and requires Python 2.5 or newer (2.5 is preinstalled in 
-Mac OS X Leopard). Sparkup also offers intregration into common text editors. Support for VIM
+Mac OS X Leopard). Sparkup also offers integration into common text editors. Support for VIM
 and TextMate are currently included.
 
 A short screencast is available here: 
@@ -20,14 +20,19 @@ A short screencast is available here:
 
 Usage and installation
 ----------------------
-You may download Sparkup from Github. [Download the latest version here](http://github.com/rstacruz/sparkup/downloads).
+You may download Sparkup from GitHub. [Download the latest version here](http://github.com/rstacruz/sparkup/downloads).
 
  - **TextMate**: Simply double-click on the `Sparkup.tmbundle` package in Finder. This
-   will install it automatically. In TextMate, open an HTML file (orset the document type to
+   will install it automatically. In TextMate, open an HTML file (or set the document type to
    HTML) type in something (e.g., `#header > h1`), then press `Ctrl` + `E`. Pressing `Tab`
    will cycle through empty elements.
 
- - **VIM**: See the `vim/README.txt` file for details.
+ - **VIM**: See the `vim/README.txt` file for installation. In VIM,
+   create or open an HTML file (or set the filetype to ``html``), type in something (e.g.
+   `#header > h1`), then press `<C-E>` whilst in **insert mode** to expand to HTML.
+   Pressing `<C-n>`  will cycle through empty elements.  Variables specified in 
+   `vim/README.txt` can be used to customise key mappings, and to add **normal mode** mappings
+   as well.
 
  - **Others/command line use**: You may put `sparkup` in your `$PATH` somewhere. You may then
    invoke it by typing `echo "(input here)" | sparkup`, or `sparkup --help` for a list of commands.
@@ -43,10 +48,10 @@ This project is inspired by [Zen Coding](http://code.google.com/p/zen-coding/) o
 
 The following people have contributed code to the project:
 
- - Guillermo O. Freschi (Tordek @ github)
+ - Guillermo O. Freschi (Tordek @ GitHub)
    Bugfixes to the parsing system
 
- - Eric Van Dewoestine (ervandew @ github)
+ - Eric Van Dewoestine (ervandew @ GitHub)
    Improvements to the VIM plugin
 
 Examples

--- a/vim/README.txt
+++ b/vim/README.txt
@@ -1,6 +1,32 @@
 Installation
 ------------
 
+With Pathogen
+^^^^^^^^^^^^^
+
+If you are using tpope's vim-pathogen, install as follows:
+
+       cd ~/.vim/bundle ; git clone https://github.com/rstacruz/sparkup.git
+       cd sparkup
+       make vim-pathogen
+
+
+With Vundle
+^^^^^^^^^^^
+
+If using Vundle, you can specify Sparkup as a bundle and installation will happen
+automatically.  Add this to your Vim configuration:
+
+       Bundle 'rstacruz/sparkup'
+
+and run the standard installation command for Vundle:
+
+       :BundleInstall
+
+
+Manual installation
+^^^^^^^^^^^^^^^^^^^
+
    1. Copy the contents of vim/ftplugin/ to your ~/.vim/ftplugin directory.
 
        (Assuming your current dir is sparkup/vim/)
@@ -11,24 +37,33 @@ Installation
        (Assuming your current dir is sparkup/vim/)
        $ cp ../sparkup.py ~/.vim/
 
-Or use tpope's vim-pathogen:
-
-       cd ~/.vim/bundle ; git clone
-       cd sparkup
-       make vim-pathogen
 
 Configuration
 -------------
 
-  g:sparkup (Default: 'sparkup') -
-    Location of the sparkup executable. You shouldn't need to change this
-    setting if you used the install option above.
+Customise the Sparkup's configuration within Vim by specifying some or all of the following
+as variables within your Vim configuration using the ``let`` directive.
 
-  g:sparkupArgs (Default: '--no-last-newline') -
-    Additional args passed to sparkup.
+   g:sparkup (Default: 'sparkup') -
+     Location of the sparkup executable. You shouldn't need to change this
+     setting if you used the install option above.
 
-  g:sparkupExecuteMapping (Default: '<c-e>') -
-    Mapping used to execute sparkup.
+   g:sparkupArgs (Default: '--no-last-newline') -
+     Additional args passed to sparkup.
 
-  g:sparkupNextMapping (Default: '<c-n>') -
-    Mapping used to jump to the next empty tag/attribute.
+   g:sparkupExecuteMapping (Default: '<c-e>') -
+     Mapping used to execute sparkup within insert mode.
+
+   g:sparkupNextMapping (Default: '<c-n>') -
+     Mapping used to jump to the next empty tag/attribute within insert mode.
+
+   g:sparkupMaps (Default: 1) -
+     Set up automatic mappings for Sparkup. If set to 0, this can be
+     used to disable creation of any mappings, which is useful if
+     full customisation is required.
+
+   g:sparkupMapsNormal (Default: 0) -
+     Set up mappings for normal mode within Vim. The same execute and next
+     mappings configured above will apply to normal mode if this option is
+     set.
+

--- a/vim/ftplugin/html/sparkup.vim
+++ b/vim/ftplugin/html/sparkup.vim
@@ -1,8 +1,10 @@
 " Sparkup
 " Installation:
-"    Copy the contents of vim/ftplugin/ to your ~/.vim/ftplugin directory.
+"    Copy the contents of vim/ftplugin/ to your ~/.vim/ftplugin directory:
 "
 "        $ cp -R vim/ftplugin ~/.vim/ftplugin/
+"
+"    or use one of the automated methods specified in the README.txt file.
 "
 " Configuration:
 "   g:sparkup (Default: 'sparkup') -
@@ -13,16 +15,20 @@
 "     Additional args passed to sparkup.
 "
 "   g:sparkupExecuteMapping (Default: '<c-e>') -
-"     Mapping used to execute sparkup.
+"     Mapping used to execute sparkup within insert mode.
 "
 "   g:sparkupNextMapping (Default: '<c-n>') -
-"     Mapping used to jump to the next empty tag/attribute.
+"     Mapping used to jump to the next empty tag/attribute within insert mode.
 "
 "   g:sparkupMaps (Default: 1) -
-"     Setup mappings?
+"     Set up automatic mappings for Sparkup. If set to 0, this can be
+"     used to disable creation of any mappings, which is useful if
+"     full customisation is required.
 "
 "   g:sparkupMapsNormal (Default: 0) -
-"     Setup mappings for normal mode?
+"     Set up mappings for normal mode within Vim. The same execute and next
+"     mappings configured above will apply to normal mode if this option is
+"     set.
 
 if !exists('g:sparkupExecuteMapping')
   let g:sparkupExecuteMapping = '<c-e>'


### PR DESCRIPTION
Clarify documentation, fix some typos and ensure all options are clearly
specified.  Previously, the normal mapping options weren't specified in
README.txt.

Also adds install instructions for Vundle.

Awesome plugin, btw!
