### PR TITLE
Eruby/ERB support

### DIFF
--- a/sparkup-unittest.py
+++ b/sparkup-unittest.py
@@ -106,7 +106,7 @@ class SparkupTest:
             },
         'Eruby tag test': {
             'input': 'erb:p',
-            'output': '<%= $1 %>$0',
+            'output': '<%=  %>$0',
             },
         'ERB block test': {
             'input': 'erb:b',

--- a/sparkup.py
+++ b/sparkup.py
@@ -50,16 +50,16 @@ class HtmlDialect(Dialect):
             'closing_tag': '?>',
             },
         'erb:p': {
-            'opening_tag' : '<%= $1',
-            'closing_tag' : ' %>',
+            'opening_tag': '<%= ',
+            'closing_tag': ' %>',
             },
         'erb:c': {
-            'opening_tag' : '%<# $1',
-            'closing_tag' : ' %>',
+            'opening_tag': '%<# ',
+            'closing_tag': ' %>',
             },
         'erb:d': {
-            'opening_tag' : '<% $1',
-            'closing_tag' : ' %>',
+            'opening_tag': '<% ',
+            'closing_tag': ' %>',
             },
         'erb:b': {
             'expand': True,


### PR DESCRIPTION
I noticed that there's a somewhat limited support for PHP in Sparkup.
Nowadays I write a lot of [ERB/Eruby templates](http://en.wikipedia.org/wiki/ERuby) and since Sparkup is the best thing ever for writing HTML I decided to add support for it.

(with tests, no less)
