### PR TITLE
case insensitive expansions

### DIFF
--- a/sparkup-unittest.py
+++ b/sparkup-unittest.py
@@ -112,6 +112,7 @@ class SparkupTest:
         'ERB block test': {
             'input': 'erb:b',
             'output': '<% $2 %>\n    $1\n<% end %>$0'
+            },
         'Tag name case (#49)': {
             'input': 'groupId{foobar}',
             'output': '<groupId>foobar</groupId>$0'

--- a/sparkup-unittest.py
+++ b/sparkup-unittest.py
@@ -112,6 +112,9 @@ class SparkupTest:
         'ERB block test': {
             'input': 'erb:b',
             'output': '<% $2 %>\n    $1\n<% end %>$0'
+        'Tag name case (#49)': {
+            'input': 'groupId{foobar}',
+            'output': '<groupId>foobar</groupId>$0'
             },
         'Nested curly braces test': {
             'input': 'p{{{ title }}}',

--- a/sparkup.py
+++ b/sparkup.py
@@ -906,7 +906,7 @@ class Token:
         # Get the tag name. Default to DIV if none given.
         name = re.findall('^([\w\-:]*)', self.str)[0]
         if self.parser.options.options['namespaced-elements'] == True:
-            name = name.lower().replace('-', ':')
+            name = name.replace('-', ':')
 
         # Find synonyms through this thesaurus
         synonyms = self.parser.dialect.synonyms


### PR DESCRIPTION
(found this on an old branch, guess I forgot to create a pull request for it)

fixes #49.

this may not be the desired behavior. html is case insensitive and
xhtml[1] states that html element and attribute names must be lower
case.

[1] http://www.w3.org/TR/xhtml1/#h-4.2