### PR TITLE
Bad transform for `node[attr=value+foobar]`

### DIFF
--- a/sparkup.py
+++ b/sparkup.py
@@ -446,7 +446,12 @@ class Parser:
             str = str[:-len(match[0])]
 
         # Split by the element separators
-        for token in re.split('(<|>|\+(?!\\s*\+|$))', str):
+        tokens = re.split(r'(<|>|\+(?!\\s*\+|$))', str)
+        for i in range(0, len(tokens) - 1):
+            while i < len(tokens) - 1 and re.search(r'\[[^\]]*$|\{[^\}]*$', tokens[i]):
+                tokens[i] += tokens[i+1]
+                tokens.pop(i+1)
+        for token in tokens:
             if token.strip() != '':
                 self.tokens.append(Token(token, parser=self))
 


### PR DESCRIPTION
It transform wrongly if separater `<`, `>`, `+` appears in attriutes (`[attr=value+foobar]`) or content (`{content in the tag + foobar}`).

```text
script[src=https://example.co.jp/foobar.js+baz]

# => Current : <script class="co jp js" type="text/javascript"></script>
# => Expect  : <script src="https://example.co.jp/foobar.js+baz" type="text/javascript"></script>
```

Now it roughly split by the separater character appearance.

This patch fixes wrong token division afterward:
if unclosed `[` or `{` appears, concatenate it with the following token.
